### PR TITLE
Fixing typo in authy-ssh

### DIFF
--- a/authy-ssh
+++ b/authy-ssh
@@ -127,7 +127,7 @@ function install_authy() {
       esac
 
       yellow "Generating initial config on ${config_file}..."
-      echo "banner=Good job! You've securely log-in with Authy." > "${config_file}"
+      echo "banner=Good job! You've securely logged in with Authy." > "${config_file}"
       echo "api_key=${authy_api_key}" >> "${config_file}"
       echo "default_verify_action=${default_verify_action}" >> "${config_file}"
     else


### PR DESCRIPTION
Caught this while watching the video.
