### PR TITLE
Use exec and login shell in run_shell

### DIFF
--- a/authy-ssh
+++ b/authy-ssh
@@ -327,6 +327,8 @@ function run_shell() {
         debug "running shell: $SHELL"
         exec -l $SHELL
     fi
+
+    exit $?
 }
 
 function find_authy_id() {


### PR DESCRIPTION
Use exec instead of a subcommand to replace the current authy-ssh process.
Use the -l flag to run the new shell as a login shell.
