### PR TITLE
Deny access for non-interactive shell

### DIFF
--- a/authy-ssh
+++ b/authy-ssh
@@ -347,6 +347,20 @@ function test_authy_ssh() {
     run "test"
 }
 
+function check_interactive() {
+# kills connection for non-interactive shells for users that are using authy
+    if [[ $(find_authy_id) ]]
+    then    
+        fd=0
+        if [ -t "$fd" ]
+        then
+            debug "This is interactive terminal. Doing auth."
+        else
+            exit 0 # Shell is not interactive. Can't do anything.
+        fi
+    fi
+}
+
 function login() {
     authy_token="$1"
     mode="$2"
@@ -467,6 +481,7 @@ case $1 in
         check_config_file
         AUTHY_API_KEY="$(read_config api_key)"
         check_api_key "run"
+        check_interactive
         run
         ;;
     protect)


### PR DESCRIPTION
If the shell is not interactive there is no way to do a 2-step auth.
So the check_interactive function just kills the script.
