### PR TITLE
60 seconds timeout on read of authy token

### DIFF
--- a/authy-ssh
+++ b/authy-ssh
@@ -433,7 +433,12 @@ function run() {
     while :
     do
         echo -n "Authy Token (type 'sms' to request a SMS token): "
-        read authy_token
+        read -t 60 authy_token
+        if [ $? -ne 0 ]
+        then
+            debug "Timeout on Authy Token read."
+            exit $?
+        fi
 
         case $authy_token in
             sms) request_sms ;;


### PR DESCRIPTION
When ssh connects from the scripts on the local side 
(this should not normally occur) authy-ssh script was waiting 
for authy token, which was never coming.

One example is bash-completion that connects in background 
to check for remote folders, and bash just stops responding 
when you press tab.

This commit introduces 60 seconds timeout on authy token input.
This way scripts are no longer locking up forever.
Downside - user must enter token quicker.
In case of sms there maybe not enough time for sms to arrive.
