### PR TITLE
Bugfix for bash 4

### DIFF
--- a/authy-ssh
+++ b/authy-ssh
@@ -425,7 +425,7 @@ function register_user_on_authy() {
 }
 
 function run_shell() {
-    if [ $SSH_ORIGINAL_COMMAND ] # when user runs: ssh server <command>
+    if [[ "$SSH_ORIGINAL_COMMAND" != "" ]] # when user runs: ssh server <command>
     then
         debug "running command: $SSH_ORIGINAL_COMMAND"
         exec /bin/bash -c "${SSH_ORIGINAL_COMMAND}"


### PR DESCRIPTION
Before this fix, a user that was not authy-ssh enabled trying to git push would receive the following error.

```
/usr/local/bin/authy-ssh: line 428: [: git-receive-pack: unary operator expected
```
