### PR TITLE
authy-ssh: fix typo in error message "permisisons" -> "permissions"

### DIFF
--- a/authy-ssh
+++ b/authy-ssh
@@ -58,7 +58,7 @@ function require_root() {
     find_sshd_config
     if [[ ! -w $SSHD_CONFIG ]]
     then
-      red "root permisisons are required to run this command. try again using sudo"
+      red "root permissions are required to run this command. try again using sudo"
       exit $FAIL
     fi
 }


### PR DESCRIPTION
Fixed a typo in an output error message. SHA1 sum will need to be recalculated, but I assumed the repo owner(s) would prefer to do that for everyone's sake.
