### PR TITLE
Added ability to disable authy-ssh when on same private network

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,15 @@ you should end up with an authorized_keys file that looks like:
 
 The previous command will ask you the user ssh public key, cellphone and email.
 
+## Disable when both on private network.
+
+Append at end of your `/etc/ssh/sshd_config` file these lines:
+
+    Match Address 10.10.0.0/24
+        ForceCommand /usr/local/bin/authy-ssh shell
+
+More about `Match` you can read [here](http://manpages.ubuntu.com/manpages/lucid/man5/sshd_config.5.html).
+
 ## Uninstall
 
 To uninstall type:

--- a/authy-ssh
+++ b/authy-ssh
@@ -660,6 +660,9 @@ case $1 in
         AUTHY_API_KEY="$(read_config api_key)"
         protect_user "$2"
         ;;
+    shell)
+        run_shell
+        ;;
     version)
         echo "Authy SSH v${VERSION}"
         exit 0

--- a/authy-ssh.sha1sum
+++ b/authy-ssh.sha1sum
@@ -1,1 +1,1 @@
-5b3f274341f99adbe045e973d4a3accf9b21ea71  authy-ssh
+2251d999ed4877a87b454358ad46bda8aaae968e  authy-ssh


### PR DESCRIPTION
I don't know if anybody else need this, but I did, so commit/pull request was made. Nothing fancy, just added one more command to run shell (that authy-ssh was running after successful token authorization) and little documentation.

Maybe this could be done without modifying authy-ssh but this seemed the fastest route to me. Cheers!
