### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Type the following command in the terminal:
 
-    $ curl -O 'https://raw.github.com/authy/authy-ssh/master/authy-ssh'
+    $ curl -O 'https://raw.githubusercontent.com/authy/authy-ssh/master/authy-ssh'
     $ sudo bash authy-ssh install /usr/local/bin
 
 Then enable two-factor for your user:


### PR DESCRIPTION
Use the correct domain for the script.
`curl` doesn't follow redirects by default _(at least on my system - Amazon Linux)_, so with the previous instructions the download would silently fail