### PR TITLE
Fix Debian service restarting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Restart your SSH server (look below if you are not on Ubuntu).
 
 **Debian**
 
-    sudo /etc/init.d/sshd restart
+    sudo service sshd restart
 
 **RedHat and Fedora Core Linux**
 


### PR DESCRIPTION
The `service` utility is actually important to use. It does some things like normalize the environment, etc. Directly invoking /etc/init.d/foobar scripts is simply wrong and should not be used.